### PR TITLE
Explicitly load 'websocket/frame/data' to resolve autoloading issue

### DIFF
--- a/lib/websocket-client-simple/client.rb
+++ b/lib/websocket-client-simple/client.rb
@@ -1,4 +1,5 @@
 require 'websocket/handshake/client'
+require 'websocket/frame/data'
 require 'websocket/frame/incoming/client'
 require 'websocket/frame/outgoing/client'
 


### PR DESCRIPTION
Similar to https://github.com/nedap/websocket-client-simple-nedap/pull/5

There seems to be some autoloading issue again (most probably for Ruby 2.4 only).

Example error:
```
NoMethodError: undefined method `set_mask' for #<WebSocket::Frame::Data:0x00007fe218b6ecc8>
```

Let's load `'websocket/frame/data' ` explicitly in case there is some other `Data` which replaces it when error happens.